### PR TITLE
Add validation messages for Fikir creation

### DIFF
--- a/GirisimciBulmaPlatform/GirisimciBulmaPlatform.Client/Pages/FikirEkle.razor
+++ b/GirisimciBulmaPlatform/GirisimciBulmaPlatform.Client/Pages/FikirEkle.razor
@@ -98,6 +98,7 @@
                                                 <option value="@katogori.Id">@katogori.KatagoriAdi</option>
                                             }
                                         </InputSelect>
+                                        <ValidationMessage For="@(() => fikir.KatagoriId)" />
                                     </div>
 
                                     <div class="col-span-full form-group">
@@ -109,12 +110,14 @@
                                     <div class="col-span-full form-group">
                                         <label for="short_description" class="form-label">Kısa Açıklama</label>
                                         <InputTextArea @bind-Value=fikir.FikirAciklama DisplayName="Fikir Kısa Açıklama" class="form-control h-[90px] resize-none" id="short_description" rows="4"></InputTextArea>
+                                        <ValidationMessage For="@(() => fikir.FikirAciklama)" />
                                     </div>
 
                                     <div class="col-span-full form-group">
                                         <label for="description" class="form-label">Açıklama</label>
                                         <InputTextArea @bind-Value=fikir.FikirDetay DisplayName="Fikir Açıklama" class="form-control h-[150px] resize-none" id="description" rows="10"></InputTextArea>
-                                    </div
+                                        <ValidationMessage For="@(() => fikir.FikirDetay)" />
+                                    </div>
 
                                     <div class="col-span-full form-group">
                                         <label for="description" class="form-label">Fotoğraflar</label>

--- a/GirisimciBulmaPlatform/GirisimciBulmaPlatform.Shared/Models/Fikir.cs
+++ b/GirisimciBulmaPlatform/GirisimciBulmaPlatform.Shared/Models/Fikir.cs
@@ -22,6 +22,7 @@ namespace GirisimciBulmaPlatform.Shared.Models
 		public string? FikirDetay { get; set; }
         public string? BosAlan { get; set; }
         public int? KullaniciId { get; set; }
+        [Required(ErrorMessage = "Kategori seçilmesi gereklidir")]
         public int? KatagoriId { get; set; }
         public string? KapakFoto { get; set; }
 


### PR DESCRIPTION
## Summary
- require KatagoriId in `Fikir` model
- show validation messages for category, short description and detail in `FikirEkle`

## Testing
- `dotnet build GirisimciBulmaPlatform.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e77029508333ade538a8302942d0