### PR TITLE
Add toast on invalid form submission

### DIFF
--- a/GirisimciBulmaPlatform/GirisimciBulmaPlatform.Client/Pages/FikirEkle.razor
+++ b/GirisimciBulmaPlatform/GirisimciBulmaPlatform.Client/Pages/FikirEkle.razor
@@ -250,6 +250,11 @@
     {
         await JSRuntime.InvokeVoidAsync("console.log", "Invalid");
         await JSRuntime.InvokeVoidAsync("console.log",fikir);
+        await JSRuntime.InvokeVoidAsync("Toast.fire", new
+        {
+            icon = "warning",
+            title = "Lütfen tüm gerekli alanları doldurun"
+        });
     }
 
     private async void OpenFilepicker()


### PR DESCRIPTION
## Summary
- display a Toast warning when the form is submitted with validation errors

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f18741ec8333b40112e14e13449f